### PR TITLE
Display warnings in yang-search

### DIFF
--- a/src/app/features/yang-search/yang-search.component.html
+++ b/src/app/features/yang-search/yang-search.component.html
@@ -116,6 +116,13 @@
 
       </form>
 
+      <br *ngIf="warnings">
+      <ngb-alert type="warning" (close)="onCloseWarnings()" role="alert" *ngIf="warnings && showWarnings && warnings.length > 0">
+        <p *ngFor="let w of warnings">
+          {{ w }}
+        </p>
+      </ngb-alert>
+
       <div *ngIf="results">
         <div class="results-header">
           <h4>Search results</h4>

--- a/src/app/features/yang-search/yang-search.component.ts
+++ b/src/app/features/yang-search/yang-search.component.ts
@@ -23,6 +23,8 @@ export class YangSearchComponent implements OnInit, OnDestroy, AfterViewInit {
   form: FormGroup;
   searchingProgress = false;
   error: any;
+  warnings = [];
+  showWarnings = true;
 
   resultsContainerWidth = '100%';
 
@@ -226,6 +228,8 @@ export class YangSearchComponent implements OnInit, OnDestroy, AfterViewInit {
     this.error = null;
     this.searchedTermToBeHighlighted = this.form.get('searchTerm').value;
     this.results = null;
+    this.showWarnings = true;
+    this.warnings = []
     this.currentColDefs = this.allColDefs.filter((col: ColDef) => this.form.get('outputColumns').value.indexOf(col.field) !== -1);
     const input = {
       'searched-term': this.form.get('searchTerm').value,
@@ -244,6 +248,12 @@ export class YangSearchComponent implements OnInit, OnDestroy, AfterViewInit {
       takeUntil(this.componentDestroyed)
     ).subscribe(
       results => {
+        if (results['max-hits']) {
+          this.warnings.push('Maximum number of results reached. Not all results will be shown.')
+        }
+        if (results['timeout']) {
+          this.warnings.push('Timeout while searching. Please try searching for something more specific.')
+        }
         this.results = results;
       },
       err => {
@@ -357,5 +367,9 @@ export class YangSearchComponent implements OnInit, OnDestroy, AfterViewInit {
       )
     ]));
 
+  }
+
+  onCloseWarnings() {
+    this.showWarnings = false;
   }
 }


### PR DESCRIPTION
This resolves #76 and #78

Added a modal to notify the user when either a timeout was hit or
the maximum number of results is being shown.