### PR TITLE
Disable results grid auto-resizing

### DIFF
--- a/src/app/features/yang-search/yang-search.component.html
+++ b/src/app/features/yang-search/yang-search.component.html
@@ -135,7 +135,6 @@
         </div>
         <div class="results-grid-container" [ngStyle]="{minWidth: resultsContainerWidth}">
           <yc-ag-grid tableId="searchResults"
-                      domLayout="autoHeight"
                       entityName="Module"
                       entityNamePlural="Modules"
                       [suppressHorizontalScroll]="false"


### PR DESCRIPTION
The official docs for ag-grid don't recommend
auto-resize for tables with >1000 rows for
performance reasons. The results grid can display
up to 2000 results.

This resolves #81